### PR TITLE
fix clusterrolebinding manifest to allow namespace different from "default"

### DIFF
--- a/deployments/helm/monitor/templates/clusterrolebinding.yaml
+++ b/deployments/helm/monitor/templates/clusterrolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: monitor
-  namespace: default
+  namespace: {{ Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: monitor


### PR DESCRIPTION
Hello,

While installing emco-monitor with Helm, I ran into the following issue:
If you try to install emco-monitor into a namespace different from "default", the clusterrolebinding will still be created in the namespace "default", because its value is hardcoded, and emco-monitor will be unable to query Kubernetes API.

With this change, the clusterrolebinding will be deployed in the namespace of the Helm release, like the other objects of this Helm chart.

It is a very small change, and this workflow of PR might not be the most adapted to the project ?

